### PR TITLE
Separate out Nodes from Wallets

### DIFF
--- a/html/css/custom.css
+++ b/html/css/custom.css
@@ -1,6 +1,6 @@
 /*! Place your custom styles here */
-.exchanges .row div.col-sm-4 {
-  min-height: 100px;
+.nodes .row div.col-sm-6 {
+  min-height: 90px;
 }
 
 .wallets .row div.col-sm-6 {
@@ -8,6 +8,10 @@
 }
 
 .services .row div.col-sm-4 {
+  min-height: 100px;
+}
+
+.exchanges .row div.col-sm-4 {
   min-height: 100px;
 }
 
@@ -88,11 +92,11 @@ p.question {
   margin-bottom: 1.04em;
 }
 
-.exchanges div a:hover, .wallets div a:hover, .services div a:hover {
+.nodes div a:hover, .wallets div a:hover, .services div a:hover, .exchanges div a:hover{
   border-bottom: 3px solid #F08B16;
 }
 
-.exchanges div a, .wallets div a, .services div a {
+.nodes div a, .wallets div a, .services div a, .exchanges div a{
   padding: 2em;
   width: 100%;
   height: 120px;

--- a/html/index.html
+++ b/html/index.html
@@ -67,8 +67,8 @@ gtag('config', 'UA-17656782-2');
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="#exchanges" class="inner-link">
-                                            Exchanges
+                                        <a href="#nodes" class="inner-link">
+                                            Nodes
                                         </a>
                                     </li>
                                     <li>
@@ -79,6 +79,11 @@ gtag('config', 'UA-17656782-2');
                                     <li>
                                         <a href="#services" class="inner-link">
                                             Services
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a href="#exchanges" class="inner-link">
+                                            Exchanges
                                         </a>
                                     </li>
                                     <li>
@@ -184,81 +189,12 @@ gtag('config', 'UA-17656782-2');
                     </div>
                 </div>
             </section>
-            <a id="exchanges"></a>
+            <a id="nodes"></a>
             <section class="space--xxs text-center gray">
-                <div class="container exchanges">
+                <div class="container nodes">
                     <div class="row">
                         <div class="col-xs-12">
-                            <h3>Exchanges</h3>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://www.viabtc.com/announcement/detail?id=3" target="_blank"><img alt="ViaBTC" src="img/exchanges/viabtc.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://support.bittrex.com/hc/en-us/articles/115000808991-Statement-on-Bitcoin-Cash-BCC-" target="_blank"><img alt="Bittrex" src="img/exchanges/bittrex.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="http://blog.kraken.com/post/1150/bitcoin-cash-and-a-critical-alert-for-bitcoin-margin-traders/" target="_blank"><img alt="Kraken" src="img/exchanges/kraken.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://cex.io/" target="_blank"><img alt="Cexio" src="img/exchanges/cexio.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://blog.okex.com/2017/07/31/okex-to-offer-bcc-btc-trading-pair-immediately-after-bcc-launch/" target="_blank"><img alt="OKEx" src="img/exchanges/kex.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://www.huobi.com/p/content/notice/getNotice?id=624" target="_blank"><img alt="Houbi" src="img/exchanges/houbi.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="http://korbitblog.tumblr.com/post/163440038518/%EC%95%88%EB%82%B4-bitcoin-cash-bcc-user-activated-hard-fork" target="_blank"><img alt="Korbit" src="img/exchanges/korbit.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://www.btcbox.co.jp/market-bcc.html" target="_blank"><img alt="BtcBox" src="img/exchanges/btcbox.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://www.toubi.com/news/view/283" target="_blank"><img alt="Toubi" src="img/exchanges/toubi.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="http://blog.coinfloor.co.uk/post/163532243506/coinfloor-to-list-bitcoin-cash-bch-in-addition" target="_blank"><img alt="Coinfloor" src="img/exchanges/coinfloor.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://changelly.com/" target="_blank"><img alt="Changelly" src="img/exchanges/changelly.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://blog.btcpop.co/2017/07/19/preparation-for-hard-forks/" target="_blank"><img alt="BTCPOP" src="img/exchanges/btcpop.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://www.bitstarex.com/service/article.html?id=18" target="_blank"><img alt="Bitstarex" src="img/exchanges/bitstarex.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://blog.mercadobitcoin.com.br/entenda-com-o-mercado-bitcoin-as-mudan%C3%A7as-do-bitcoin-esperadas-para-agosto-20bb31a0d9c3" target="_blank"><img alt="Mercado Bitcoin" src="img/exchanges/mercadobitcoin.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://shapeshift.io/" target="_blank"><img alt="ShapeShift" src="img/exchanges/shapeshift.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://blog.hitbtc.com/our-statement-on-bitcoincash-support/" target="_blank"><img alt="HitBTC" src="img/exchanges/hitbtc.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://uphold.com/en/blog/posts/uphold/bitcoin-cash-live-on-uphold" target="_blank"><img alt="Uphold" src="img/exchanges/uphold.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://poloniex.com/" target="_blank"><img alt="Poloniex" src="img/exchanges/poloniex.png"></a>
-                        </div>
-                        <div class="col-sm-4 col-md-3 vertical-align">
-                            <a href="https://www.bithumb.com/" target="_blank"><img alt="Bithumb" src="img/exchanges/bithumb.png"></a>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <a id="wallets"></a>
-            <section class="space--xxs text-center">
-                <div class="container wallets">
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <h3>Wallets</h3>
+                            <h3>Nodes</h3>
                         </div>
                     </div>
                     <div class="row">
@@ -274,6 +210,20 @@ gtag('config', 'UA-17656782-2');
                         <div class="col-sm-6 col-md-4 vertical-align">
                             <a href="https://bitcoinxt.software/" target="_blank"><img alt="BitcoinXT" src="img/wallets/bitcoinxt.png"></a>
                         </div>
+
+                    </div>
+                </div>
+            </section>
+            <a id="wallets"></a>
+            <section class="space--xxs text-center">
+                <div class="container wallets">
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <h3>Wallets</h3>
+                        </div>
+                    </div>
+                    <div class="row">
+
                         <div class="col-sm-6 col-md-4 vertical-align">
                             <a href="http://www.ledgerwallet.com/" target="_blank"><img alt="Ledger" src="img/wallets/ledger.png"></a>
                         </div>
@@ -339,6 +289,75 @@ gtag('config', 'UA-17656782-2');
                         </div>
                         <div class="col-sm-4 col-md-3 vertical-align">
                             <a href="https://tippr.rocketr.net" target="_blank"><img alt="Tippr" src="img/services/tippr.png"></a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <a id="exchanges"></a>
+            <section class="space--xxs text-center gray">
+                <div class="container exchanges">
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <h3>Exchanges</h3>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://www.viabtc.com/announcement/detail?id=3" target="_blank"><img alt="ViaBTC" src="img/exchanges/viabtc.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://support.bittrex.com/hc/en-us/articles/115000808991-Statement-on-Bitcoin-Cash-BCC-" target="_blank"><img alt="Bittrex" src="img/exchanges/bittrex.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="http://blog.kraken.com/post/1150/bitcoin-cash-and-a-critical-alert-for-bitcoin-margin-traders/" target="_blank"><img alt="Kraken" src="img/exchanges/kraken.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://cex.io/" target="_blank"><img alt="Cexio" src="img/exchanges/cexio.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://blog.okex.com/2017/07/31/okex-to-offer-bcc-btc-trading-pair-immediately-after-bcc-launch/" target="_blank"><img alt="OKEx" src="img/exchanges/kex.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://www.huobi.com/p/content/notice/getNotice?id=624" target="_blank"><img alt="Houbi" src="img/exchanges/houbi.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="http://korbitblog.tumblr.com/post/163440038518/%EC%95%88%EB%82%B4-bitcoin-cash-bcc-user-activated-hard-fork" target="_blank"><img alt="Korbit" src="img/exchanges/korbit.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://www.btcbox.co.jp/market-bcc.html" target="_blank"><img alt="BtcBox" src="img/exchanges/btcbox.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://www.toubi.com/news/view/283" target="_blank"><img alt="Toubi" src="img/exchanges/toubi.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="http://blog.coinfloor.co.uk/post/163532243506/coinfloor-to-list-bitcoin-cash-bch-in-addition" target="_blank"><img alt="Coinfloor" src="img/exchanges/coinfloor.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://changelly.com/" target="_blank"><img alt="Changelly" src="img/exchanges/changelly.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://blog.btcpop.co/2017/07/19/preparation-for-hard-forks/" target="_blank"><img alt="BTCPOP" src="img/exchanges/btcpop.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://www.bitstarex.com/service/article.html?id=18" target="_blank"><img alt="Bitstarex" src="img/exchanges/bitstarex.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://blog.mercadobitcoin.com.br/entenda-com-o-mercado-bitcoin-as-mudan%C3%A7as-do-bitcoin-esperadas-para-agosto-20bb31a0d9c3" target="_blank"><img alt="Mercado Bitcoin" src="img/exchanges/mercadobitcoin.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://shapeshift.io/" target="_blank"><img alt="ShapeShift" src="img/exchanges/shapeshift.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://blog.hitbtc.com/our-statement-on-bitcoincash-support/" target="_blank"><img alt="HitBTC" src="img/exchanges/hitbtc.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://uphold.com/en/blog/posts/uphold/bitcoin-cash-live-on-uphold" target="_blank"><img alt="Uphold" src="img/exchanges/uphold.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://poloniex.com/" target="_blank"><img alt="Poloniex" src="img/exchanges/poloniex.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align">
+                            <a href="https://www.bithumb.com/" target="_blank"><img alt="Bithumb" src="img/exchanges/bithumb.png"></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This change separates the "Wallets" section into "Nodes" and "Wallets"

Also moves "Exchanges" section to lower down on the webpage

![pr3](https://user-images.githubusercontent.com/22730787/30832499-1f1e7f8a-a200-11e7-8ebe-09ac62722d4d.png)
