### PR TITLE
Add news about November network upgrade

### DIFF
--- a/html/css/custom.css
+++ b/html/css/custom.css
@@ -3,6 +3,22 @@
   margin-bottom: 40px;
 }
 
+p.release {
+  color: white;
+  padding-top: .5em;
+  font-size: 1.2em;
+}
+
+.release a, .release a:visited {
+  color: white;
+  font-weight: 700;
+  text-decoration: none;
+}
+.release a:hover {
+  color: white;
+  text-decoration: underline;
+}
+
 .benefits p {
   margin-bottom: 0;
 }

--- a/html/index.html
+++ b/html/index.html
@@ -12,7 +12,7 @@
         <link href="css/stack-interface.css" rel="stylesheet" type="text/css" media="all" />
         <link href="css/socicon.css" rel="stylesheet" type="text/css" media="all" />
         <link href="css/theme.css" rel="stylesheet" type="text/css" media="all" />
-        <link href="css/custom.css" rel="stylesheet" type="text/css" media="all" />
+        <link href="css/custom.css?v=1" rel="stylesheet" type="text/css" media="all" />
         <link href="https://fonts.googleapis.com/css?family=Open+Sans:200,300,400,400i,500,600,700%7CMerriweather:300,300i" rel="stylesheet">
         <!-- Global Site Tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-17656782-2"></script>
@@ -125,6 +125,11 @@ gtag('config', 'UA-17656782-2');
                             <p class="lead">
                                 Peer-to-Peer Electronic Cash
                             </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <p class="release">The Bitcoin Cash <a href="https://www.bitcoinabc.org/november" target="_blank">network upgrade</a> is scheduled for November 13th, 2017.</p>
                         </div>
                     </div>
                     <div class="row">


### PR DESCRIPTION
Since Bitcoin Cash is hard forking on Nov. 13th it is only appropriate to put a message on the website. This should go live tomorrow, but I wanted to get feedback from others on the messaging. Personally I think the message needs to meet these criteria:

1) Informs users that the networking is being upgraded.
2) Should be prominently displayed where everyone will see it.
3) Keeps it to a single sentence that looks good in the header.
4) Links to the press release from the ABC team.

Here is a preview of what I was thinking:

![upgrade](https://user-images.githubusercontent.com/83898/32262929-8dc0dfc2-be94-11e7-8a48-c07eed1d0f0a.png)
