### PR TITLE
Remove notice of upcoming network upgrade.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -128,11 +128,6 @@ gtag('config', 'UA-17656782-2');
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-sm-12">
-                            <p class="release">The Bitcoin Cash <a href="https://www.bitcoinabc.org/november" target="_blank">network upgrade</a> is scheduled for November 13th, 2017.</p>
-                        </div>
-                    </div>
-                    <div class="row">
                         <div class="col-sm-12 ticker">
                             <span id="ticker_value">Loading...</span>
                         </div>


### PR DESCRIPTION
The event is in the past, so we can remove the notice about it.