### PR TITLE
Clarified ticker symbol

### DIFF
--- a/translations/en.yml
+++ b/translations/en.yml
@@ -127,4 +127,4 @@ en:
       - question: "What is the ticker symbol for Bitcoin Cash?"
         answer:
           - |
-            Bitcoin Cash is represented by a number of different ticker symbols depending on the service or wallet. BCH/BCC are the most popular tickers, with XBC being used to meet the International Standard for currency codes (ISO 4217).
+            Bitcoin Cash is represented by a number of different ticker symbols depending on the service or wallet. BCH is the most popular ticker, with XBC being used to meet the International Standard for currency codes (ISO 4217).

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -127,4 +127,4 @@ en:
       - question: "What is the ticker symbol for Bitcoin Cash?"
         answer:
           - |
-            Bitcoin Cash is represented by a number of different ticker symbols depending on the service or wallet. BCH is the most popular ticker, with XBC being used to meet the International Standard for currency codes (ISO 4217).
+            Bitcoin Cash is usually represented by the ticker symbol BCH.


### PR DESCRIPTION
Removed reference to the specific ticker symbol BCC. The market has spoken, BCH is the most popular ticker, other less popular tickers do not need to be referenced. Some stats: 
38 of 42 exchanges linked on the site use BCH (BitBay, Binance, Bittrex, and OKEX, do not), 
13 of 15 services use BCH (Blockdozer and Coinmix do not), 
8 of 8 projects use BCH 
22 of the 22 wallets use BCH,
5 of 5 nodes use BCH in their source code or documentation.