### PR TITLE
Included two font subsets to improve text rendering

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -17,7 +17,7 @@
         <link href="/css/socicon.css" rel="stylesheet" type="text/css" media="all" />
         <link href="/css/theme.css" rel="stylesheet" type="text/css" media="all" />
         <link href="/css/custom.css?v=1" rel="stylesheet" type="text/css" media="all" />
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans:200,300,400,400i,500,600,700%7CMerriweather:300,300i" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:200,300,400,400i,500,600,700%7CMerriweather:300,300i&subset=latin,latin-ext" rel="stylesheet">
         <!-- Global Site Tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-17656782-2"></script>
         <script>


### PR DESCRIPTION
Hi,
as discussed in issues, this commit fixes #114. Missing characters in font in several languages (see [relevant SO](https://stackoverflow.com/questions/14303677/languages-supported-by-latin-vs-latin-extended-glyphs-in-fonts-on-google-web) for reference). I have only tested this by locally modifying the live webpage and it worked, but I have not yet built it myself.