### PR TITLE
Use body's instead of window's outer width

### DIFF
--- a/html/js/scripts.js
+++ b/html/js/scripts.js
@@ -734,7 +734,7 @@ mr = (function (mr, $, window, document){
                 offset      = dropdown.offset().left;
                 width       = dropdown.outerWidth(true);
                 offsetRight = offset + width;
-                winWidth    = jQuery(window).outerWidth(true);
+                winWidth    = jQuery('.containerMeasure').outerWidth(true);
                 leftCorrect = jQuery('.containerMeasure').outerWidth() - width;
 
             if(offsetRight > winWidth){


### PR DESCRIPTION
As the language menu is bigger than regular menus, in some situations it extends the window to the right. Any logic that uses the window's outer width may see a width greater than the device's resolution and we end up with scrolling. Therefore, instead of the window we use the `div.containerMeasure` that is already added to the body with the specific purpose of measuring the body's width. Seems to work consistently across resolutions.