### PR TITLE
Move Flowee from Nodes to Projects

### DIFF
--- a/index.html.erb
+++ b/index.html.erb
@@ -265,9 +265,6 @@ gtag('config', 'UA-17656782-2');
                         <div class="col-sm-6 col-md-6 vertical-align to-animate">
                             <a href="https://www.bitprim.org/" target="_blank"><img alt="Bitprim" src="/img/wallets/bitprim.png"></a>
                         </div>
-                        <div class="col-sm-6 col-md-6 vertical-align to-animate">
-                            <a href="http://www.flowee.org/" target="_blank"><img alt="Flowee The Hub" src="/img/wallets/flowee.png"></a>
-                        </div>
                     </div>
                 </div>
             </section>
@@ -483,6 +480,9 @@ gtag('config', 'UA-17656782-2');
                         </div>
                         <div class="col-sm-4 col-md-3 vertical-align">
                             <a href="https://www.coinline.co.nz/marco-coino/" target="_blank"><img alt="Marco Coino BCH brick-and-mortar merchant directory" src="/img/projects/marcocoino.png"></a>
+                        </div>
+                        <div class="col-sm-4 col-md-3 vertical-align to-animate">
+                            <a href="http://www.flowee.org/" target="_blank"><img alt="Flowee The Hub" src="/img/wallets/flowee.png"></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
It seems that Flowee is not really suitable for mining, as it does not implement activation code for the Network Upgrade.

https://twitter.com/btcfork/status/988734398630678528

This means it does not really belong in the "Nodes" section. "Projects" would be a more appropriate category.